### PR TITLE
check all assertions

### DIFF
--- a/lib/turd/assert.rb
+++ b/lib/turd/assert.rb
@@ -31,9 +31,7 @@ module Turd
 
           if option == :response_headers || option == :response_body
             value.each do |v|
-              if response.options[option].include?(v)
-                return return_http_response(response)
-              else
+              if !response.options[option].include?(v)
                 response.options.store(:failed, option)
                 raise AssertionFailure.new(return_http_response(response)), "#{option} substring failure. expected #{v}, got #{response.options[option]}"
               end
@@ -42,13 +40,9 @@ module Turd
             if response.options[option] > value
               response.options.store(:failed, option)
               raise AssertionFailure.new(return_http_response(response)), "#{option} timing value was greater than allowed. expected #{value}, got #{response.options[option]}"
-            else
-              return return_http_response(response)
             end
           else
-            if response.options[option] == value
-              return return_http_response(response)
-            else
+            if response.options[option] != value
               response.options.store(:failed, option)
               raise AssertionFailure.new(return_http_response(response)), "#{option} did not match response definition. expected #{value}, got #{response.options[option]}"
             end
@@ -56,6 +50,7 @@ module Turd
         end
       end
 
+      return return_http_response(response)
     end
 
     def self.return_http_response(response)


### PR DESCRIPTION
This lets us test endpoints with multiple assertions.  Instead of returning early on a success, this waits for all the assertions to succeed before returning the success.  Here's a sample `:response` object:

``` jsos
    "response": {
      "response_code": 422,
      "response_headers": [
        "Content-Type: application/json"
      ],
      "response_body": [
        "\"message\":\"Validation Failed\"",
        "\"field\":\"content_type\""
      ]
    }
```
